### PR TITLE
Музыка,батл экран,движение батл экрана

### DIFF
--- a/core/src/com/myteam/game/SDGame.java
+++ b/core/src/com/myteam/game/SDGame.java
@@ -1,31 +1,26 @@
 package com.myteam.game;
 
-import com.badlogic.gdx.ApplicationAdapter;
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.SpriteBatch;
-import com.badlogic.gdx.utils.ScreenUtils;
+import com.badlogic.gdx.Game;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.myteam.game.screens.battle.BattleScreen;
 
-public class SDGame extends ApplicationAdapter {
-	SpriteBatch batch;
-	Texture img;
-	
-	@Override
-	public void create () {
-		batch = new SpriteBatch();
-		img = new Texture("badlogic.jpg");
+
+public class SDGame extends Game {
+	BitmapFont font;
+
+	public void create() {
+
+		// libGDX по умолчанию использует Arial шрифт.
+		font = new BitmapFont();
+     	this.setScreen(new BattleScreen(this));
 	}
 
-	@Override
-	public void render () {
-		ScreenUtils.clear(1, 0, 0, 1);
-		batch.begin();
-		batch.draw(img, 0, 0);
-		batch.end();
+	public void render() {
+
+		super.render(); // важно!
 	}
-	
-	@Override
-	public void dispose () {
-		batch.dispose();
-		img.dispose();
+
+	public void dispose() {
 	}
 }
+

--- a/core/src/com/myteam/game/screens/battle/BattleScreen.java
+++ b/core/src/com/myteam/game/screens/battle/BattleScreen.java
@@ -13,32 +13,29 @@ import com.badlogic.gdx.utils.viewport.FitViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
 import com.myteam.game.SDGame;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class BattleScreen implements Screen {
 
     final SDGame game;
 
-    TextureAtlas atlas;
-    TextureRegion regionBackground;
-    TextureRegion regionGround;
-    TextureRegion regionSquare;
-    SpriteBatch batch;
+    private TextureAtlas atlas;
+    private Background background;
+    private SpriteBatch batch;
     private Viewport viewport;
-    OrthographicCamera camera;
-    boolean inTravel = true;
-    Music MusicLoopBattleScreen;
-    float speedInTravel = 0;
+    private OrthographicCamera camera;
+    private boolean inTravel = true;
+    private Music MusicLoopBattleScreen;
 
-    public BattleScreen(final SDGame gam) {
-        game = gam;
-
+    public BattleScreen(final SDGame game) {
+        this.game = game;
     }
 
     @Override
     public void show() {
         atlas = new TextureAtlas(Gdx.files.internal("atlas.atlas"));
-        regionBackground = atlas.findRegion("Background");
-        regionGround = atlas.findRegion("Ground");
-        regionSquare = atlas.findRegion("Square");
+        background = new Background("desert", atlas);
         batch = new SpriteBatch();
         camera = new OrthographicCamera();
         camera.setToOrtho(false, 1240, 720);
@@ -52,18 +49,7 @@ public class BattleScreen implements Screen {
         Gdx.gl.glClearColor(0, 0, 0.2f, 1);
         Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
         batch.begin();
-        batch.draw(regionBackground,0, 0);
-        if (!inTravel){
-            batch.draw(regionGround,0, 0);
-        }else{
-            batch.draw(regionGround,speedInTravel, 0);
-            speedInTravel -= 5;
-            batch.draw(regionGround,speedInTravel+1240, 0);
-        }
-        if (speedInTravel == -1240){
-            speedInTravel = 0;
-        }
-        batch.draw(regionSquare,0, 0);
+        background.render(batch, inTravel);
         batch.end();
     }
 
@@ -90,5 +76,35 @@ public class BattleScreen implements Screen {
     @Override
     public void dispose() {
 
+    }
+
+    private static class Background {
+        float themeOffset;
+        TextureRegion back;
+        TextureRegion theme;
+        TextureRegion ground;
+
+
+        Background(String name, TextureAtlas atlas) {
+            back = atlas.findRegion(name + "_back");
+            theme = atlas.findRegion(name + "_theme");
+            ground = atlas.findRegion(name + "_ground");
+            themeOffset = 0;
+        }
+
+        void render(SpriteBatch batch, boolean inTravel) {
+            batch.draw(back, 0, 0);
+            if (!inTravel) {
+                batch.draw(theme, themeOffset, 0);
+            } else {
+                batch.draw(theme, themeOffset, 0);
+                themeOffset -= Gdx.graphics.getWidth() / 6 * Gdx.graphics.getDeltaTime();
+                batch.draw(theme, themeOffset + Gdx.graphics.getWidth(), 0);
+            }
+            if (themeOffset <= -Gdx.graphics.getWidth()) {
+                themeOffset = 0;
+            }
+            batch.draw(ground, 0, 0);
+        }
     }
 }

--- a/core/src/com/myteam/game/screens/battle/BattleScreen.java
+++ b/core/src/com/myteam/game/screens/battle/BattleScreen.java
@@ -1,0 +1,94 @@
+package com.myteam.game.screens.battle;
+
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.Screen;
+import com.badlogic.gdx.audio.Music;
+import com.badlogic.gdx.graphics.OrthographicCamera;
+import com.badlogic.gdx.graphics.GL20;
+import com.badlogic.gdx.graphics.g2d.SpriteBatch;
+import com.badlogic.gdx.graphics.g2d.TextureAtlas;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.utils.viewport.FitViewport;
+import com.badlogic.gdx.utils.viewport.Viewport;
+import com.myteam.game.SDGame;
+
+public class BattleScreen implements Screen {
+
+    final SDGame game;
+
+    TextureAtlas atlas;
+    TextureRegion regionBackground;
+    TextureRegion regionGround;
+    TextureRegion regionSquare;
+    SpriteBatch batch;
+    private Viewport viewport;
+    OrthographicCamera camera;
+    boolean inTravel = true;
+    Music MusicLoopBattleScreen;
+    float speedInTravel = 0;
+
+    public BattleScreen(final SDGame gam) {
+        game = gam;
+
+    }
+
+    @Override
+    public void show() {
+        atlas = new TextureAtlas(Gdx.files.internal("atlas.atlas"));
+        regionBackground = atlas.findRegion("Background");
+        regionGround = atlas.findRegion("Ground");
+        regionSquare = atlas.findRegion("Square");
+        batch = new SpriteBatch();
+        camera = new OrthographicCamera();
+        camera.setToOrtho(false, 1240, 720);
+        viewport = new FitViewport(1240, 720, camera);
+        MusicLoopBattleScreen = Gdx.audio.newMusic(Gdx.files.internal("MusicLoopBattleScreen.wav"));
+        MusicLoopBattleScreen.play();
+    }
+
+    @Override
+    public void render(float delta) {
+        Gdx.gl.glClearColor(0, 0, 0.2f, 1);
+        Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
+        batch.begin();
+        batch.draw(regionBackground,0, 0);
+        if (!inTravel){
+            batch.draw(regionGround,0, 0);
+        }else{
+            batch.draw(regionGround,speedInTravel, 0);
+            speedInTravel -= 5;
+            batch.draw(regionGround,speedInTravel+1240, 0);
+        }
+        if (speedInTravel == -1240){
+            speedInTravel = 0;
+        }
+        batch.draw(regionSquare,0, 0);
+        batch.end();
+    }
+
+    @Override
+    public void resize(int width, int height) {
+        viewport.update(width, height);
+    }
+
+    @Override
+    public void pause() {
+
+    }
+
+    @Override
+    public void resume() {
+
+    }
+
+    @Override
+    public void hide() {
+
+    }
+
+    @Override
+    public void dispose() {
+
+    }
+}

--- a/core/src/com/myteam/game/screens/battle/BattleScreen.java
+++ b/core/src/com/myteam/game/screens/battle/BattleScreen.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 public class BattleScreen implements Screen {
 
-    final SDGame game;
+    private final SDGame game;
 
     private TextureAtlas atlas;
     private Background background;
@@ -26,7 +26,7 @@ public class BattleScreen implements Screen {
     private Viewport viewport;
     private OrthographicCamera camera;
     private boolean inTravel = true;
-    private Music MusicLoopBattleScreen;
+    private Music musicLoopBattleScreen;
 
     public BattleScreen(final SDGame game) {
         this.game = game;
@@ -38,10 +38,10 @@ public class BattleScreen implements Screen {
         background = new Background("desert", atlas);
         batch = new SpriteBatch();
         camera = new OrthographicCamera();
-        camera.setToOrtho(false, 1240, 720);
-        viewport = new FitViewport(1240, 720, camera);
-        MusicLoopBattleScreen = Gdx.audio.newMusic(Gdx.files.internal("MusicLoopBattleScreen.wav"));
-        MusicLoopBattleScreen.play();
+        camera.setToOrtho(false, Gdx.graphics.getWidth(), Gdx.graphics.getHeight());
+        viewport = new FitViewport(Gdx.graphics.getWidth(), Gdx.graphics.getHeight(), camera);
+        musicLoopBattleScreen = Gdx.audio.newMusic(Gdx.files.internal("MusicLoopBattleScreen.wav"));
+        musicLoopBattleScreen.play();
     }
 
     @Override
@@ -75,7 +75,8 @@ public class BattleScreen implements Screen {
 
     @Override
     public void dispose() {
-
+        musicLoopBattleScreen.dispose();
+        atlas.dispose();
     }
 
     private static class Background {
@@ -91,7 +92,7 @@ public class BattleScreen implements Screen {
             ground = atlas.findRegion(name + "_ground");
             themeOffset = 0;
         }
-
+        
         void render(SpriteBatch batch, boolean inTravel) {
             batch.draw(back, 0, 0);
             if (!inTravel) {


### PR DESCRIPTION
1)Создал пакет screens в core модуле
2)Внутри пакета реализовал класс
BattleScreen - реализует экран боя:
Начальные опции:
На сцене в лупе играет аудио: MusicLoopBattleScreen (взять в discord->design)
отрисовывать текстуры: Background, Ground, Squre в порядке перечисления
текстуры необходимо упаковать и использовать через атлас текстур (https://github.com/infernoSSS/SDProj/pull/2 , http://www.libgdx.ru/2015/01/texture-packer.html)
Создать boolean флаг "inTravel":
если false: все текстуры отрисовываются в установленном порядке от координат 0,0
если true: необходимо эмулировать анимацию перемещения экрана слева на право, для этого необходимо сдвигать текстуру graund в лево с некоторой скоростью (на усмотрение разработчика)
NOTE возможно потребуется несколько текстур выстроенных по горизонтали и перемещающихся циклически
В рамках сцены необходимо использовать FillViewPort (https://libgdx.com/wiki/graphics/viewports)